### PR TITLE
linking of test app needs libUMP

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -5,7 +5,7 @@ CFLAGS ?= -Wall
 all: test
 
 test: ../config.mk test.c
-	$(CC) $(CFLAGS) -o $@ test.c -lEGL -lGLESv2
+	$(CC) $(CFLAGS) -o $@ test.c -lEGL -lGLESv2 -lUMP
 
 clean:
 	rm -f test


### PR DESCRIPTION
issue detected on [Buildroot](http://buildroot.net/), with `r2p4`

```
make[2]: Entering directory `/home/buildroot/build/instance-0/output/build/sunxi-mali-d343311efc8db166d8371b28494f0f27b6a58724/test'
/home/buildroot/build/instance-0/output/host/usr/bin/armv5-ctng-linux-gnueabi-gcc -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64   -Os  -lm -ldl -lpthread -o test test.c -lEGL -lGLESv2
/home/buildroot/build/instance-0/output/host/opt/ext-toolchain/bin/../lib/gcc/armv5-ctng-linux-gnueabi/4.8.3/../../../../armv5-ctng-linux-gnueabi/bin/ld: warning: libUMP.so.2, needed by /home/buildroot/build/instance-0/output/host/usr/arm-buildroot-linux-gnueabi/sysroot/usr/lib/libMali.so, not found (try using -rpath or -rpath-link)
/home/buildroot/build/instance-0/output/host/usr/arm-buildroot-linux-gnueabi/sysroot/usr/lib/libEGL.so: undefined reference to `ump_close'
/home/buildroot/build/instance-0/output/host/usr/arm-buildroot-linux-gnueabi/sysroot/usr/lib/libEGL.so: undefined reference to `ump_mapped_pointer_get'
/home/buildroot/build/instance-0/output/host/usr/arm-buildroot-linux-gnueabi/sysroot/usr/lib/libEGL.so: undefined reference to `ump_secure_id_get'
/home/buildroot/build/instance-0/output/host/usr/arm-buildroot-linux-gnueabi/sysroot/usr/lib/libEGL.so: undefined reference to `ump_mapped_pointer_release'
/home/buildroot/build/instance-0/output/host/usr/arm-buildroot-linux-gnueabi/sysroot/usr/lib/libMali.so: undefined reference to `ump_reference_add'
/home/buildroot/build/instance-0/output/host/usr/arm-buildroot-linux-gnueabi/sysroot/usr/lib/libMali.so: undefined reference to `ump_size_get'
/home/buildroot/build/instance-0/output/host/usr/arm-buildroot-linux-gnueabi/sysroot/usr/lib/libEGL.so: undefined reference to `ump_reference_release'
/home/buildroot/build/instance-0/output/host/usr/arm-buildroot-linux-gnueabi/sysroot/usr/lib/libEGL.so: undefined reference to `ump_open'
collect2: error: ld returned 1 exit status
```
